### PR TITLE
Upgrade to lang.regex

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -16,7 +16,6 @@ dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "lang.regexp"},
 	{org = "ballerina", name = "log"},
-	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "test"}
 ]
 modules = [
@@ -77,16 +76,6 @@ modules = [
 
 [[package]]
 org = "ballerina"
-name = "lang.string"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.regexp"}
-]
-
-[[package]]
-org = "ballerina"
 name = "lang.value"
 version = "0.0.0"
 dependencies = [
@@ -123,19 +112,6 @@ scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"}
-]
-
-[[package]]
-org = "ballerina"
-name = "regex"
-version = "1.4.3"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.string"}
-]
-modules = [
-	{org = "ballerina", packageName = "regex", moduleName = "regex"}
 ]
 
 [[package]]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -14,7 +14,6 @@ version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "io"},
-	{org = "ballerina", name = "lang.regexp"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "test"}
@@ -70,9 +69,6 @@ name = "lang.regexp"
 version = "0.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.regexp", moduleName = "lang.regexp"}
 ]
 
 [[package]]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -79,6 +79,7 @@ modules = [
 org = "ballerina"
 name = "lang.string"
 version = "0.0.0"
+scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.regexp"}
@@ -128,6 +129,7 @@ dependencies = [
 org = "ballerina"
 name = "regex"
 version = "1.4.3"
+scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.string"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -14,6 +14,7 @@ version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "lang.regexp"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "test"}
@@ -70,11 +71,15 @@ version = "0.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
+modules = [
+	{org = "ballerina", packageName = "lang.regexp", moduleName = "lang.regexp"}
+]
 
 [[package]]
 org = "ballerina"
 name = "lang.string"
 version = "0.0.0"
+scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.regexp"}
@@ -124,6 +129,7 @@ dependencies = [
 org = "ballerina"
 name = "regex"
 version = "1.4.3"
+scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.string"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -14,6 +14,7 @@ version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "lang.regexp"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "test"}
@@ -69,6 +70,9 @@ name = "lang.regexp"
 version = "0.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.regexp", moduleName = "lang.regexp"}
 ]
 
 [[package]]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -14,7 +14,6 @@ version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "io"},
-	{org = "ballerina", name = "lang.regexp"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "test"}
@@ -71,15 +70,11 @@ version = "0.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
-modules = [
-	{org = "ballerina", packageName = "lang.regexp", moduleName = "lang.regexp"}
-]
 
 [[package]]
 org = "ballerina"
 name = "lang.string"
 version = "0.0.0"
-scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.regexp"}
@@ -129,7 +124,6 @@ dependencies = [
 org = "ballerina"
 name = "regex"
 version = "1.4.3"
-scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.string"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -79,7 +79,6 @@ modules = [
 org = "ballerina"
 name = "lang.string"
 version = "0.0.0"
-scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.regexp"}
@@ -129,7 +128,6 @@ dependencies = [
 org = "ballerina"
 name = "regex"
 version = "1.4.3"
-scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.string"}

--- a/ballerina/component_group_reader.bal
+++ b/ballerina/component_group_reader.bal
@@ -20,7 +20,7 @@ isolated function readComponentGroup(string compositeText, EdiSchema ediSchema, 
         return ();
     }
 
-    string[] components = split(compositeText, ediSchema.delimiters.component);
+    string[] components = check split(compositeText, ediSchema.delimiters.component);
     if fieldSchema.truncatable {
         int minFields = getMinimumCompositeFields(fieldSchema);
         if components.length() < minFields {

--- a/ballerina/edi_translator.bal
+++ b/ballerina/edi_translator.bal
@@ -30,7 +30,7 @@ type EdiContext record {|
 public isolated function fromEdiString(string ediText, EdiSchema schema) returns json|Error {
     EdiContext context = {schema};
     EdiUnitSchema[] currentMapping = context.schema.segments;
-    context.ediText = splitSegments(ediText, context.schema.delimiters.segment);
+    context.ediText = check splitSegments(ediText, context.schema.delimiters.segment);
     EdiSegmentGroup rootGroup = check readSegmentGroup(currentMapping, context, true);
     return rootGroup;
 }

--- a/ballerina/repetition_reader.bal
+++ b/ballerina/repetition_reader.bal
@@ -18,7 +18,7 @@ import ballerina/log;
 
 isolated function readRepetition(string repeatText, string repeatDelimiter, EdiSchema mapping, EdiFieldSchema fieldMapping)
         returns SimpleArray|EdiComponentGroup[]|Error {
-    string[] fields = split(repeatText, repeatDelimiter);
+    string[] fields = check split(repeatText, repeatDelimiter);
     SimpleArray|EdiComponentGroup[] repeatValues = getArray(fieldMapping.dataType);
     if fields.length() == 0 {
         // None of the repeating values are provided. Return an empty array.

--- a/ballerina/segment_group_reader.bal
+++ b/ballerina/segment_group_reader.bal
@@ -30,9 +30,7 @@ isolated function readSegmentGroup(EdiUnitSchema[] currentUnitSchema, EdiContext
         if segSchema is () {
             return error Error("Segment schema cannot be empty.");
         }
-        string sDesc = context.ediText[context.rawIndex];
-        string:RegExp newline = re `\n`;
-        string segmentDesc = newline.replaceAll(sDesc, "");
+        string segmentDesc = removeLineBreaks(context.ediText[context.rawIndex]);
         // There can be segments that do not follow standard EDI format (e.g. EDIFACT UNA segment).
         // Therefore, it is necessary to check and skip ignore segments before spliting into fields.
         boolean ignoreCurrentSegment = false;

--- a/ballerina/segment_group_reader.bal
+++ b/ballerina/segment_group_reader.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import ballerina/log;
-import ballerina/regex;
 
 type SegmentGroupContext record {|
     int schemaIndex = 0;
@@ -32,8 +31,8 @@ isolated function readSegmentGroup(EdiUnitSchema[] currentUnitSchema, EdiContext
             return error Error("Segment schema cannot be empty.");
         }
         string sDesc = context.ediText[context.rawIndex];
-        string segmentDesc = regex:replaceAll(sDesc, "\n", "");
-        
+        string:RegExp newline = re `\n`;
+        string segmentDesc = newline.replaceAll(sDesc, "");
         // There can be segments that do not follow standard EDI format (e.g. EDIFACT UNA segment).
         // Therefore, it is necessary to check and skip ignore segments before spliting into fields.
         boolean ignoreCurrentSegment = false;
@@ -81,11 +80,11 @@ isolated function readSegmentGroup(EdiUnitSchema[] currentUnitSchema, EdiContext
         }
     }
     if rootGroup && ediSchema.delimiters.'field != "FL" {
-        foreach int i in context.rawIndex...(context.ediText.length() - 1) {
+        foreach int i in context.rawIndex ... (context.ediText.length() - 1) {
             string unmatchedRaw = context.ediText[context.rawIndex];
-            string[] unmatchedSegFields = split(unmatchedRaw, ediSchema.delimiters.'field);
+            string[] unmatchedSegFields = check split(unmatchedRaw, ediSchema.delimiters.'field);
             if ediSchema.ignoreSegments.indexOf(unmatchedSegFields[0], 0) == () {
-               return error Error(string `Segment text does not match with the schema. 
+                return error Error(string `Segment text does not match with the schema. 
                     Segment: ${context.ediText[context.rawIndex]}, Curren row: ${context.rawIndex}`);
             }
         }

--- a/ballerina/subcomponent_group_reader.bal
+++ b/ballerina/subcomponent_group_reader.bal
@@ -19,7 +19,7 @@ isolated function readSubcomponentGroup(string scGroupText, EdiSchema schema, Ed
         return ();
     }
 
-    string[] subcomponents = split(scGroupText, schema.delimiters.subcomponent);
+    string[] subcomponents = check split(scGroupText, schema.delimiters.subcomponent);
     if compSchema.truncatable {
         int minFields = getMinimumSubcomponentFields(compSchema);
         if subcomponents.length() < minFields {

--- a/ballerina/tests/edi_modification_tests.bal
+++ b/ballerina/tests/edi_modification_tests.bal
@@ -12,8 +12,8 @@ function testSegmentModification(string testName) returns error? {
     string ediOut = check toEdiString(message, schema);
     string ediExpected = check getOutputEDI(testName);
 
-    ediOut = prepareEDI(ediOut, schema);
-    ediIn = prepareEDI(ediExpected, schema);
+    ediOut = check prepareEDI(ediOut, schema);
+    ediIn = check prepareEDI(ediExpected, schema);
 
     test:assertEquals(ediOut, ediIn);
 }

--- a/ballerina/tests/segment_reading_tests.bal
+++ b/ballerina/tests/segment_reading_tests.bal
@@ -13,8 +13,8 @@ function testSegments(string testName) returns error? {
     string ediOut = check toEdiString(message, schema);
     check saveEDIMessage(testName, ediOut);
 
-    ediOut = prepareEDI(ediOut, schema);
-    ediIn = prepareEDI(ediIn, schema);
+    ediOut = check prepareEDI(ediOut, schema);
+    ediIn = check prepareEDI(ediIn, schema);
 
     test:assertEquals(ediOut, ediIn);
 }
@@ -32,8 +32,8 @@ function testFixedLengthEDIs(string testName) returns error? {
     string ediOut = check toEdiString(message, schema);
     check saveEDIMessage(testName, ediOut);
 
-    ediOut = prepareEDI(ediOut, schema);
-    ediIn = prepareEDI(ediIn, schema);
+    ediOut = check prepareEDI(ediOut, schema);
+    ediIn = check prepareEDI(ediIn, schema);
 
     test:assertEquals(ediOut, ediIn);
 }
@@ -51,8 +51,8 @@ function testDynamicLengthEDIs(string testName) returns error? {
     string ediOut = check toEdiString(message, schema);
     check saveEDIMessage(testName, ediOut);
 
-    ediOut = prepareEDI(ediOut, schema);
-    ediIn = prepareEDI(ediIn, schema);
+    ediOut = check prepareEDI(ediOut, schema);
+    ediIn = check prepareEDI(ediIn, schema);
 
     test:assertEquals(ediOut, ediIn);
 }

--- a/ballerina/tests/test_utils.bal
+++ b/ballerina/tests/test_utils.bal
@@ -1,6 +1,6 @@
 import ballerina/io;
-import ballerina/regex;
 import ballerina/file;
+import ballerina/lang.regexp;
 
 function getTestSchema(string testName) returns EdiSchema|error {
     string schemaPath = check file:joinPath("tests", "resources", testName, "schema.json");
@@ -37,11 +37,11 @@ function saveJsonMessage(string testName, json message) returns error? {
     check io:fileWriteJson(path, message);
 }
 
-function prepareEDI(string edi, EdiSchema schema) returns string {
-    string e1 = regex:replaceAll(edi, " ", "");
-    e1 = regex:replaceAll(e1, "\n", "");
-    e1 = regex:replaceAll(e1, validateDelimiter((schema.delimiters.decimalSeparator ?: ".")) + "0", "");
-    e1 = regex:replaceAll(e1, "0", "");
-    return e1;
+function prepareEDI(string edi, EdiSchema schema) returns string|error {
+    string:RegExp decSeprator = check regexp:fromString(schema.delimiters.decimalSeparator ?: ".");
+    string:RegExp nulSpaces = re ` |\n|0`;
+    string preparedEDI = nulSpaces.replaceAll(edi, "");
+    preparedEDI = decSeprator.replaceAll(preparedEDI, "");
+    return preparedEDI;
 }
 

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -136,9 +136,8 @@ isolated function splitSegments(string text, string delimiter) returns string[]|
     if segmentLines[segmentLines.length() - 1] == "" {
         string _ = segmentLines.remove(segmentLines.length() - 1);
     }
-    string:RegExp newline = re `\n`;
     foreach int i in 0 ... (segmentLines.length() - 1) {
-        segmentLines[i] = newline.replaceAll(segmentLines[i], "");
+        segmentLines[i] = removeLineBreaks(segmentLines[i]);
     }
     return segmentLines;
 }
@@ -261,3 +260,7 @@ isolated function addPadding(string value, int requiredLength) returns string {
     return paddedValue;
 }
 
+isolated function removeLineBreaks(string value) returns string {
+    string:RegExp newline = re `\n`;
+    return newline.replaceAll(value, "");
+}

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,6 @@ subprojects {
         ballerinaStdLibs "io.ballerina.stdlib:io-ballerina:${project.stdlibIoVersion}"
         ballerinaStdLibs "io.ballerina.stdlib:log-ballerina:${project.stdlibLogVersion}"
         ballerinaStdLibs "io.ballerina.stdlib:file-ballerina:${project.stdlibFileVersion}"
-        ballerinaStdLibs "io.ballerina.stdlib:regex-ballerina:${project.stdlibRegexVersion}"
 
         ballerinaStdLibs "io.ballerina.stdlib:os-ballerina:${project.stdlibOsVersion}"
         ballerinaStdLibs "io.ballerina.stdlib:time-ballerina:${project.stdlibTimeVersion}"

--- a/changelog.md
+++ b/changelog.md
@@ -8,3 +8,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - [Add support for field length constraints (min/max)](https://github.com/ballerina-platform/ballerina-library/issues/5896).
+- [Updated dependencies to use lang.regex instead of ballerina/regex](https://github.com/ballerina-platform/ballerina-library/issues/5941)


### PR DESCRIPTION
## Purpose
Updated dependencies in the module-ballerina-edi to use `lang.regex` instead of `ballerina/regex`.

Fixes : https://github.com/ballerina-platform/ballerina-library/issues/5941

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility