### PR TITLE
Rewrite user-facing docs for the envelope-aware API

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ directly. Each package groups related message types by business domain.
 | [`ballerinax/edifact.d03a.shipping`](https://central.ballerina.io/ballerinax/edifact.d03a.shipping) | Container operations, customs declarations, vessel departures, cargo reports. |
 | [`ballerinax/edifact.d03a.supplychain`](https://central.ballerina.io/ballerinax/edifact.d03a.supplychain) | Purchase orders, order responses, delivery forecasts, inventory, despatch advices. |
 
-Each message type is a submodule (e.g. `mINVOIC`, `mORDERS`) exposing `fromEdiString`,
-`toEdiString`, and `getEDINames`:
+Each message type is available as a submodule (e.g. `finance.mINVOIC`, `supplychain.mORDERS`)
+exposing `fromEdiString` / `toEdiString`; each package's default module also provides
+`getEDINames()` to list its supported message types:
 
 ```ballerina
 import ballerina/io;
@@ -94,7 +95,7 @@ import ballerinax/edifact.d03a.finance.mINVOIC;
 
 public function main() returns error? {
     string ediText = check io:fileReadString("resources/invoice.edi");
-    mINVOIC:EDI_INVOIC_Invoice invoice = check mINVOIC:fromEdiString(ediText);
+    mINVOIC:EDI_INVOIC_Invoice_message invoice = check mINVOIC:fromEdiString(ediText);
     io:println(invoice);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ The fastest path is to generate a typed parser from an EDIFACT or X12 spec using
 Run the following from your Ballerina package to generate the records and parser functions into its default module:
 
 ```bash
-# 1. Convert the EDIFACT D03A ORDERS spec into a Ballerina EDI schema
-$ bal edi convertEdifactSchema -v d03a -t ORDERS -o resources/orders-schema.json
+# 1. Convert the EDIFACT D03A ORDERS spec into a Ballerina EDI schema.
+#    -o is a directory; the schema is written to resources/ORDERS.json (named after the message type).
+$ bal edi convertEdifactSchema -v d03a -t ORDERS -o resources
 
 # 2. Generate Ballerina records and parser functions into the default module
-$ bal edi codegen -i resources/orders-schema.json -o orders.bal
+$ bal edi codegen -i resources/ORDERS.json -o orders.bal
 ```
 
 For X12 use `bal edi convertX12Schema` — see the [edi-tools documentation](https://github.com/ballerina-platform/edi-tools). For larger projects, the generated EDI code can live in its own package within a Ballerina workspace alongside your integration.

--- a/README.md
+++ b/README.md
@@ -35,28 +35,28 @@ The fastest path is to generate a typed parser from an EDIFACT or X12 spec using
 
 ### Step 1: Generate a parser from a spec
 
+Run the following from your Ballerina package to generate the records and parser functions into its default module:
+
 ```bash
 # 1. Convert the EDIFACT D03A ORDERS spec into a Ballerina EDI schema
 $ bal edi convertEdifactSchema -v d03a -t ORDERS -o resources/orders-schema.json
 
-# 2. Generate Ballerina records and parser functions from the schema
-$ bal edi codegen -i resources/orders-schema.json -o modules/orders/orders.bal
+# 2. Generate Ballerina records and parser functions into the default module
+$ bal edi codegen -i resources/orders-schema.json -o orders.bal
 ```
 
-For X12 use `bal edi convertX12Schema` — see the [edi-tools documentation](https://github.com/ballerina-platform/edi-tools).
+For X12 use `bal edi convertX12Schema` — see the [edi-tools documentation](https://github.com/ballerina-platform/edi-tools). For larger projects, the generated EDI code can live in its own package within a Ballerina workspace alongside your integration.
 
 ### Step 2: Use the generated code
 
-The generated module exposes typed records and parser functions for the schema. The top-level
-interchange record is named after the schema (an `ORDERS` schema produces `ORDERSInterchange`):
+The generated code defines typed records and parser functions in the same default module, named after the schema (an `ORDERS` schema produces `ORDERSInterchange`):
 
 ```ballerina
 import ballerina/io;
-import sample.orders;
 
 public function main() returns error? {
     string ediText = check io:fileReadString("resources/order.edi");
-    orders:ORDERSInterchange interchange = check orders:interchangeFromEdiString(ediText);
+    ORDERSInterchange interchange = check interchangeFromEdiString(ediText);
     foreach var txn in interchange.transactions {
         if txn.body is error {
             io:println("Quarantined: ", (<error>txn.body).message());
@@ -119,13 +119,13 @@ for full signatures, parameters, error types, and envelope semantics.
 
 | Function | Purpose |
 |----------|---------|
-| `getSchema` | Load and validate a JSON EDI schema into an `EdiSchema`. |
 | `fromEdiString` / `toEdiString` | Parse a transaction body to JSON / serialize JSON back to EDI text. |
 | `x12HeadersFromEdiString` / `x12HeadersFromEdiFile` | Schema-free peek at X12 ISA/GS headers — routing and partner identification. |
 | `edifactHeadersFromEdiString` / `edifactHeadersFromEdiFile` | Schema-free peek at EDIFACT UNB/UNH headers. |
 | `headersFromEdiString` / `headersFromEdiFile` | Schema-driven header-only parse. |
 | `interchangeFromEdiString` | Parse the full envelope hierarchy into typed records, with fail-safe per-transaction bodies. |
 | `interchangeToEdiString` | Serialize a full interchange back to EDI text (recomputes envelope counts). |
+| `getSchema` | Load and validate a JSON EDI schema into an `EdiSchema`. |
 
 ## Customizing the generated schema
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The Ballerina `edi` module provides schema-driven, envelope-aware conversion bet
 The `edi` module is pulled in automatically when you import it. To generate typed parsers from EDI schemas, install the companion CLI tool:
 
 ```bash
-$ bal tool pull edi
+bal tool pull edi
 ```
 
 ## Quickstart
@@ -40,10 +40,10 @@ Run the following from your Ballerina package to generate the records and parser
 ```bash
 # 1. Convert the EDIFACT D03A ORDERS spec into a Ballerina EDI schema.
 #    -o is a directory; the schema is written to resources/ORDERS.json (named after the message type).
-$ bal edi convertEdifactSchema -v d03a -t ORDERS -o resources
+bal edi convertEdifactSchema -v d03a -t ORDERS -o resources
 
 # 2. Generate Ballerina records and parser functions into the default module
-$ bal edi codegen -i resources/ORDERS.json -o orders.bal
+bal edi codegen -i resources/ORDERS.json -o orders.bal
 ```
 
 For X12 use `bal edi convertX12Schema` — see the [edi-tools documentation](https://github.com/ballerina-platform/edi-tools). For larger projects, the generated EDI code can live in its own package within a Ballerina workspace alongside your integration.
@@ -60,7 +60,7 @@ public function main() returns error? {
     ORDERSInterchange interchange = check interchangeFromEdiString(ediText);
     foreach var txn in interchange.transactions {
         if txn.body is error {
-            io:println("Quarantined: ", (<error>txn.body).message());
+            io:println("Quarantined: ", txn.body.message());
             continue;
         }
         io:println(txn.body);
@@ -108,8 +108,8 @@ published. Instead, convert the X12 schema you are licensed to use into a Baller
 generate a typed parser from it, exactly like the EDIFACT quickstart above:
 
 ```bash
-$ bal edi convertX12Schema -i schema.xsd -o resources/850-schema.json
-$ bal edi codegen -i resources/850-schema.json -o po.bal
+bal edi convertX12Schema -i schema.xsd -o resources/850-schema.json
+bal edi codegen -i resources/850-schema.json -o po.bal
 ```
 
 ## Exposed APIs

--- a/README.md
+++ b/README.md
@@ -11,29 +11,29 @@
 
 Electronic Data Interchange (EDI) is a standard for exchanging business documents — purchase orders, invoices, shipping notices — between trading partners in a structured, machine-readable format. The two most widely used standards are **X12** (North America) and **EDIFACT** (international).
 
-The Ballerina `edi` module lets you:
+The Ballerina `edi` module provides schema-driven, envelope-aware conversion between EDI text and JSON or typed Ballerina records, in both directions. The companion [`edi-tools` CLI](https://github.com/ballerina-platform/edi-tools) generates Ballerina records and ready-to-use parser code from a schema, so most users never have to call the low-level functions in this module directly.
 
-- **Inspect envelope headers** without a schema — fastest path for routing and partner identification (X12 ISA/GS, EDIFACT UNB/UNH).
-- **Parse the full envelope hierarchy** into typed `EdiInterchange` / `EdiFunctionalGroup` / `EdiTransaction` records, with fail-safe per-transaction body — process what you can and quarantine what you can't.
-- **Parse a transaction body into JSON or typed Ballerina records** (X12, EDIFACT, or any custom format).
-- **Serialize JSON / records back to EDI text** for outbound flows.
-- **Drive parsing from a JSON schema** — either [generated from an X12 / EDIFACT spec](https://github.com/ballerina-platform/edi-tools) or [defined manually](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md) for partner-specific formats.
+### Key features
 
-The companion [`edi-tools` CLI](https://github.com/ballerina-platform/edi-tools) generates Ballerina records and ready-to-use parser code from a schema, so most users never have to call the low-level functions in this module directly.
+- **Schema-free envelope header inspection** — the fastest path for routing and partner identification (X12 ISA/GS, EDIFACT UNB/UNH), with no schema required.
+- **Full envelope hierarchy parsing** into typed `EdiInterchange` / `EdiFunctionalGroup` / `EdiTransaction` records, with a fail-safe per-transaction body — process what you can and quarantine what you can't.
+- **Transaction body parsing** into JSON or typed Ballerina records (X12, EDIFACT, or any custom format).
+- **Serialization** of JSON / records back to EDI text for outbound flows.
+- **Schema-driven** parsing from a JSON schema — either [generated from an X12 / EDIFACT spec](https://github.com/ballerina-platform/edi-tools) or [defined manually](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md) for partner-specific formats.
 
-## Quickstart
+## Setup
 
-The fastest path is to generate a typed parser from an EDIFACT or X12 spec using `edi-tools` and call the generated functions from your code.
-
-### Install
-
-The `edi` module is pulled in automatically when you import it. Install the CLI tool:
+The `edi` module is pulled in automatically when you import it. To generate typed parsers from EDI schemas, install the companion CLI tool:
 
 ```bash
 $ bal tool pull edi
 ```
 
-### Generate a parser from an EDIFACT spec
+## Quickstart
+
+The fastest path is to generate a typed parser from an EDIFACT or X12 spec using `edi-tools` and call the generated functions from your code.
+
+### Step 1: Generate a parser from a spec
 
 ```bash
 # 1. Convert the EDIFACT D03A ORDERS spec into a Ballerina EDI schema
@@ -45,7 +45,7 @@ $ bal edi codegen -i resources/orders-schema.json -o modules/orders/orders.bal
 
 For X12 use `bal edi convertX12Schema` — see the [edi-tools documentation](https://github.com/ballerina-platform/edi-tools).
 
-### Use the generated code
+### Step 2: Use the generated code
 
 The generated module exposes typed records and parser functions for the schema. The top-level
 interchange record is named after the schema (an `ORDERS` schema produces `ORDERSInterchange`):
@@ -151,6 +151,15 @@ parser. A minimal schema looks like:
 The [Schema Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md)
 documents the full grammar — delimiters, segments and segment groups, fields / components /
 sub-components, the `envelope` declaration, and the additional configuration options.
+
+## Examples
+
+The [`examples`](https://github.com/ballerina-platform/module-ballerina-edi/tree/main/examples) directory contains runnable end-to-end samples:
+
+- [Custom EDI schema](https://github.com/ballerina-platform/module-ballerina-edi/tree/main/examples/custom-edi-schema) — define a custom EDI schema and generate a typed parser from it (the codegen workflow foundation).
+- [Vendor router](https://github.com/ballerina-platform/module-ballerina-edi/tree/main/examples/edi-vendor-router) — schema-free header inspection to route inbound messages by trading partner.
+- [Parser to Kafka](https://github.com/ballerina-platform/module-ballerina-edi/tree/main/examples/edi-parser-to-kafka) — parse an interchange with fail-safe per-transaction bodies, forward good transactions to Kafka, and quarantine the rest.
+- [Order generator](https://github.com/ballerina-platform/module-ballerina-edi/tree/main/examples/edi-order-generator) — build and serialize a full interchange with `interchangeToEdiString`, including a parse/serialize round-trip.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ generate a typed parser from it, exactly like the EDIFACT quickstart above:
 
 ```bash
 $ bal edi convertX12Schema -i schema.xsd -o resources/850-schema.json
-$ bal edi codegen -i resources/850-schema.json -o modules/po/po.bal
+$ bal edi codegen -i resources/850-schema.json -o po.bal
 ```
 
 ## Exposed APIs

--- a/README.md
+++ b/README.md
@@ -47,13 +47,16 @@ For X12 use `bal edi convertX12Schema` — see the [edi-tools documentation](htt
 
 ### Use the generated code
 
+The generated module exposes typed records and parser functions for the schema. The top-level
+interchange record is named after the schema (an `ORDERS` schema produces `ORDERSInterchange`):
+
 ```ballerina
 import ballerina/io;
 import sample.orders;
 
 public function main() returns error? {
     string ediText = check io:fileReadString("resources/order.edi");
-    orders:OrdersInterchange interchange = check orders:interchangeFromEdiString(ediText);
+    orders:ORDERSInterchange interchange = check orders:interchangeFromEdiString(ediText);
     foreach var txn in interchange.transactions {
         if txn.body is error {
             io:println("Quarantined: ", (<error>txn.body).message());
@@ -64,11 +67,96 @@ public function main() returns error? {
 }
 ```
 
+## Working with standard EDI formats
+
+### EDIFACT — prebuilt packages
+
+For common UN/EDIFACT D03A message types you do not need to generate anything: import a ready-made
+package from the `ballerinax` organization and call its `fromEdiString` / `toEdiString` functions
+directly. Each package groups related message types by business domain.
+
+| Package | Domain |
+|---------|--------|
+| [`ballerinax/edifact.d03a.finance`](https://central.ballerina.io/ballerinax/edifact.d03a.finance) | Credit/debit advices, payment orders, invoices, ledger and tax messages. |
+| [`ballerinax/edifact.d03a.logistics`](https://central.ballerina.io/ballerinax/edifact.d03a.logistics) | Cargo summaries, transport instructions, booking confirmations, dangerous goods. |
+| [`ballerinax/edifact.d03a.manufacturing`](https://central.ballerina.io/ballerinax/edifact.d03a.manufacturing) | Metered consumption, quality data, safety hazards, waste disposal. |
+| [`ballerinax/edifact.d03a.retail`](https://central.ballerina.io/ballerinax/edifact.d03a.retail) | Product and price data, rebate orders, retail settlements, product inquiries. |
+| [`ballerinax/edifact.d03a.services`](https://central.ballerina.io/ballerinax/edifact.d03a.services) | Insurance, healthcare, job applications, berth management, claims. |
+| [`ballerinax/edifact.d03a.shipping`](https://central.ballerina.io/ballerinax/edifact.d03a.shipping) | Container operations, customs declarations, vessel departures, cargo reports. |
+| [`ballerinax/edifact.d03a.supplychain`](https://central.ballerina.io/ballerinax/edifact.d03a.supplychain) | Purchase orders, order responses, delivery forecasts, inventory, despatch advices. |
+
+Each message type is a submodule (e.g. `mINVOIC`, `mORDERS`) exposing `fromEdiString`,
+`toEdiString`, and `getEDINames`:
+
+```ballerina
+import ballerina/io;
+import ballerinax/edifact.d03a.finance.mINVOIC;
+
+public function main() returns error? {
+    string ediText = check io:fileReadString("resources/invoice.edi");
+    mINVOIC:EDI_INVOIC_Invoice invoice = check mINVOIC:fromEdiString(ediText);
+    io:println(invoice);
+}
+```
+
+### X12 — generate from your own spec
+
+X12 message specifications are proprietary (licensed from ASC X12), so no prebuilt X12 packages are
+published. Instead, convert the X12 schema you are licensed to use into a Ballerina EDI schema and
+generate a typed parser from it, exactly like the EDIFACT quickstart above:
+
+```bash
+$ bal edi convertX12Schema -i schema.xsd -o resources/850-schema.json
+$ bal edi codegen -i resources/850-schema.json -o modules/po/po.bal
+```
+
+## Exposed APIs
+
+Most users call the generated functions rather than this module directly, but the module's public
+functions are available for advanced use. The table below is a cursory overview; see the
+[Module Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/ModuleSpecification.md)
+for full signatures, parameters, error types, and envelope semantics.
+
+| Function | Purpose |
+|----------|---------|
+| `getSchema` | Load and validate a JSON EDI schema into an `EdiSchema`. |
+| `fromEdiString` / `toEdiString` | Parse a transaction body to JSON / serialize JSON back to EDI text. |
+| `x12HeadersFromEdiString` / `x12HeadersFromEdiFile` | Schema-free peek at X12 ISA/GS headers — routing and partner identification. |
+| `edifactHeadersFromEdiString` / `edifactHeadersFromEdiFile` | Schema-free peek at EDIFACT UNB/UNH headers. |
+| `headersFromEdiString` / `headersFromEdiFile` | Schema-driven header-only parse. |
+| `interchangeFromEdiString` | Parse the full envelope hierarchy into typed records, with fail-safe per-transaction bodies. |
+| `interchangeToEdiString` | Serialize a full interchange back to EDI text (recomputes envelope counts). |
+
+## Customizing the generated schema
+
+`edi-tools` emits the schema as a JSON file before generating code. Trading partners routinely use
+variations of a standard format, so you can edit this schema to match a partner-specific layout —
+adjust delimiters, segment occurrences (`minOccurances` / `maxOccurances`), field data types, or
+list segments to skip in `ignoreSegments` — then re-run `bal edi codegen` to regenerate the typed
+parser. A minimal schema looks like:
+
+```json
+{
+    "name": "SimpleOrder",
+    "delimiters": {"segment": "~", "field": "*", "component": ":", "repetition": "^"},
+    "segments": [
+        {"code": "HDR", "tag": "header", "minOccurances": 1,
+         "fields": [{"tag": "code"}, {"tag": "orderId"}, {"tag": "organization"}, {"tag": "date"}]},
+        {"code": "ITM", "tag": "items", "maxOccurances": -1,
+         "fields": [{"tag": "code"}, {"tag": "item"}, {"tag": "quantity", "dataType": "int"}]}
+    ]
+}
+```
+
+The [Schema Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md)
+documents the full grammar — delimiters, segments and segment groups, fields / components /
+sub-components, the `envelope` declaration, and the additional configuration options.
+
 ## Documentation
 
-- [Module Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/ModuleSpecification.md) — the full API: the schema-free and schema-driven function families (with an API summary table), envelope and interchange types, error types (`InvalidEnvelopeError`, `SchemaCompatibilityError`, `SerializationError`), and envelope processing semantics (count recomputation on write, UNA handling, single interchange per call).
-- [Schema Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md) — the JSON grammar for EDI schemas: delimiters, segments and segment groups, fields / components / sub-components, the `envelope` declaration, and additional configuration.
-- [edi-tools](https://github.com/ballerina-platform/edi-tools) — converting published X12 / EDIFACT specs into schemas, generating typed records and parser functions (`codegen`), and packaging schema families as libraries (`libgen`).
+- [Module Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/ModuleSpecification.md) — the full API reference and envelope processing semantics.
+- [Schema Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md) — the JSON grammar for EDI schemas.
+- [edi-tools](https://github.com/ballerina-platform/edi-tools) — converting X12 / EDIFACT specs into schemas (`convertX12Schema` / `convertEdifactSchema`), generating typed parsers (`codegen`), and packaging schema families as libraries (`libgen`).
 
 ## Issues and projects
 

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -2,29 +2,29 @@
 
 Electronic Data Interchange (EDI) is a standard for exchanging business documents — purchase orders, invoices, shipping notices — between trading partners in a structured, machine-readable format. The two most widely used standards are **X12** (North America) and **EDIFACT** (international).
 
-The Ballerina `edi` module lets you:
+The Ballerina `edi` module provides schema-driven, envelope-aware conversion between EDI text and JSON or typed Ballerina records, in both directions. The companion [`edi-tools` CLI](https://github.com/ballerina-platform/edi-tools) generates Ballerina records and ready-to-use parser code from a schema, so most users never have to call the low-level functions in this module directly.
 
-- **Inspect envelope headers** without a schema — fastest path for routing and partner identification (X12 ISA/GS, EDIFACT UNB/UNH).
-- **Parse the full envelope hierarchy** into typed `EdiInterchange` / `EdiFunctionalGroup` / `EdiTransaction` records, with fail-safe per-transaction body — process what you can and quarantine what you can't.
-- **Parse a transaction body into JSON or typed Ballerina records** (X12, EDIFACT, or any custom format).
-- **Serialize JSON / records back to EDI text** for outbound flows.
-- **Drive parsing from a JSON schema** — either [generated from an X12 / EDIFACT spec](https://github.com/ballerina-platform/edi-tools) or [defined manually](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md) for partner-specific formats.
+### Key features
 
-The companion [`edi-tools` CLI](https://github.com/ballerina-platform/edi-tools) generates Ballerina records and ready-to-use parser code from a schema, so most users never have to call the low-level functions in this module directly.
+- **Schema-free envelope header inspection** — the fastest path for routing and partner identification (X12 ISA/GS, EDIFACT UNB/UNH), with no schema required.
+- **Full envelope hierarchy parsing** into typed `EdiInterchange` / `EdiFunctionalGroup` / `EdiTransaction` records, with a fail-safe per-transaction body — process what you can and quarantine what you can't.
+- **Transaction body parsing** into JSON or typed Ballerina records (X12, EDIFACT, or any custom format).
+- **Serialization** of JSON / records back to EDI text for outbound flows.
+- **Schema-driven** parsing from a JSON schema — either [generated from an X12 / EDIFACT spec](https://github.com/ballerina-platform/edi-tools) or [defined manually](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md) for partner-specific formats.
 
-## Quickstart
+## Setup
 
-The fastest path is to generate a typed parser from an EDIFACT or X12 spec using `edi-tools` and call the generated functions from your code.
-
-### Install
-
-The `edi` module is pulled in automatically when you import it. Install the CLI tool:
+The `edi` module is pulled in automatically when you import it. To generate typed parsers from EDI schemas, install the companion CLI tool:
 
 ```bash
 $ bal tool pull edi
 ```
 
-### Generate a parser from an EDIFACT spec
+## Quickstart
+
+The fastest path is to generate a typed parser from an EDIFACT or X12 spec using `edi-tools` and call the generated functions from your code.
+
+### Step 1: Generate a parser from a spec
 
 ```bash
 # 1. Convert the EDIFACT D03A ORDERS spec into a Ballerina EDI schema
@@ -36,7 +36,7 @@ $ bal edi codegen -i resources/orders-schema.json -o modules/orders/orders.bal
 
 For X12 use `bal edi convertX12Schema` — see the [edi-tools documentation](https://github.com/ballerina-platform/edi-tools).
 
-### Use the generated code
+### Step 2: Use the generated code
 
 The generated module exposes typed records and parser functions for the schema. The top-level
 interchange record is named after the schema (an `ORDERS` schema produces `ORDERSInterchange`):
@@ -143,8 +143,18 @@ The [Schema Specification](https://github.com/ballerina-platform/module-ballerin
 documents the full grammar — delimiters, segments and segment groups, fields / components /
 sub-components, the `envelope` declaration, and the additional configuration options.
 
+## Examples
+
+The [`examples`](https://github.com/ballerina-platform/module-ballerina-edi/tree/main/examples) directory contains runnable end-to-end samples:
+
+- [Custom EDI schema](https://github.com/ballerina-platform/module-ballerina-edi/tree/main/examples/custom-edi-schema) — define a custom EDI schema and generate a typed parser from it (the codegen workflow foundation).
+- [Vendor router](https://github.com/ballerina-platform/module-ballerina-edi/tree/main/examples/edi-vendor-router) — schema-free header inspection to route inbound messages by trading partner.
+- [Parser to Kafka](https://github.com/ballerina-platform/module-ballerina-edi/tree/main/examples/edi-parser-to-kafka) — parse an interchange with fail-safe per-transaction bodies, forward good transactions to Kafka, and quarantine the rest.
+- [Order generator](https://github.com/ballerina-platform/module-ballerina-edi/tree/main/examples/edi-order-generator) — build and serialize a full interchange with `interchangeToEdiString`, including a parse/serialize round-trip.
+
 ## Documentation
 
 - [Module Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/ModuleSpecification.md) — the full API reference and envelope processing semantics.
 - [Schema Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md) — the JSON grammar for EDI schemas.
 - [edi-tools](https://github.com/ballerina-platform/edi-tools) — converting X12 / EDIFACT specs into schemas (`convertX12Schema` / `convertEdifactSchema`), generating typed parsers (`codegen`), and packaging schema families as libraries (`libgen`).
+

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -26,28 +26,28 @@ The fastest path is to generate a typed parser from an EDIFACT or X12 spec using
 
 ### Step 1: Generate a parser from a spec
 
+Run the following from your Ballerina package to generate the records and parser functions into its default module:
+
 ```bash
 # 1. Convert the EDIFACT D03A ORDERS spec into a Ballerina EDI schema
 $ bal edi convertEdifactSchema -v d03a -t ORDERS -o resources/orders-schema.json
 
-# 2. Generate Ballerina records and parser functions from the schema
-$ bal edi codegen -i resources/orders-schema.json -o modules/orders/orders.bal
+# 2. Generate Ballerina records and parser functions into the default module
+$ bal edi codegen -i resources/orders-schema.json -o orders.bal
 ```
 
-For X12 use `bal edi convertX12Schema` — see the [edi-tools documentation](https://github.com/ballerina-platform/edi-tools).
+For X12 use `bal edi convertX12Schema` — see the [edi-tools documentation](https://github.com/ballerina-platform/edi-tools). For larger projects, the generated EDI code can live in its own package within a Ballerina workspace alongside your integration.
 
 ### Step 2: Use the generated code
 
-The generated module exposes typed records and parser functions for the schema. The top-level
-interchange record is named after the schema (an `ORDERS` schema produces `ORDERSInterchange`):
+The generated code defines typed records and parser functions in the same default module, named after the schema (an `ORDERS` schema produces `ORDERSInterchange`):
 
 ```ballerina
 import ballerina/io;
-import sample.orders;
 
 public function main() returns error? {
     string ediText = check io:fileReadString("resources/order.edi");
-    orders:ORDERSInterchange interchange = check orders:interchangeFromEdiString(ediText);
+    ORDERSInterchange interchange = check interchangeFromEdiString(ediText);
     foreach var txn in interchange.transactions {
         if txn.body is error {
             io:println("Quarantined: ", (<error>txn.body).message());
@@ -110,13 +110,13 @@ for full signatures, parameters, error types, and envelope semantics.
 
 | Function | Purpose |
 |----------|---------|
-| `getSchema` | Load and validate a JSON EDI schema into an `EdiSchema`. |
 | `fromEdiString` / `toEdiString` | Parse a transaction body to JSON / serialize JSON back to EDI text. |
 | `x12HeadersFromEdiString` / `x12HeadersFromEdiFile` | Schema-free peek at X12 ISA/GS headers — routing and partner identification. |
 | `edifactHeadersFromEdiString` / `edifactHeadersFromEdiFile` | Schema-free peek at EDIFACT UNB/UNH headers. |
 | `headersFromEdiString` / `headersFromEdiFile` | Schema-driven header-only parse. |
 | `interchangeFromEdiString` | Parse the full envelope hierarchy into typed records, with fail-safe per-transaction bodies. |
 | `interchangeToEdiString` | Serialize a full interchange back to EDI text (recomputes envelope counts). |
+| `getSchema` | Load and validate a JSON EDI schema into an `EdiSchema`. |
 
 ## Customizing the generated schema
 

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -17,7 +17,7 @@ The Ballerina `edi` module provides schema-driven, envelope-aware conversion bet
 The `edi` module is pulled in automatically when you import it. To generate typed parsers from EDI schemas, install the companion CLI tool:
 
 ```bash
-$ bal tool pull edi
+bal tool pull edi
 ```
 
 ## Quickstart
@@ -31,10 +31,10 @@ Run the following from your Ballerina package to generate the records and parser
 ```bash
 # 1. Convert the EDIFACT D03A ORDERS spec into a Ballerina EDI schema.
 #    -o is a directory; the schema is written to resources/ORDERS.json (named after the message type).
-$ bal edi convertEdifactSchema -v d03a -t ORDERS -o resources
+bal edi convertEdifactSchema -v d03a -t ORDERS -o resources
 
 # 2. Generate Ballerina records and parser functions into the default module
-$ bal edi codegen -i resources/ORDERS.json -o orders.bal
+bal edi codegen -i resources/ORDERS.json -o orders.bal
 ```
 
 For X12 use `bal edi convertX12Schema` — see the [edi-tools documentation](https://github.com/ballerina-platform/edi-tools). For larger projects, the generated EDI code can live in its own package within a Ballerina workspace alongside your integration.
@@ -51,7 +51,7 @@ public function main() returns error? {
     ORDERSInterchange interchange = check interchangeFromEdiString(ediText);
     foreach var txn in interchange.transactions {
         if txn.body is error {
-            io:println("Quarantined: ", (<error>txn.body).message());
+            io:println("Quarantined: ", txn.body.message());
             continue;
         }
         io:println(txn.body);
@@ -99,8 +99,8 @@ published. Instead, convert the X12 schema you are licensed to use into a Baller
 generate a typed parser from it, exactly like the EDIFACT quickstart above:
 
 ```bash
-$ bal edi convertX12Schema -i schema.xsd -o resources/850-schema.json
-$ bal edi codegen -i resources/850-schema.json -o po.bal
+bal edi convertX12Schema -i schema.xsd -o resources/850-schema.json
+bal edi codegen -i resources/850-schema.json -o po.bal
 ```
 
 ## Exposed APIs

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -38,13 +38,16 @@ For X12 use `bal edi convertX12Schema` — see the [edi-tools documentation](htt
 
 ### Use the generated code
 
+The generated module exposes typed records and parser functions for the schema. The top-level
+interchange record is named after the schema (an `ORDERS` schema produces `ORDERSInterchange`):
+
 ```ballerina
 import ballerina/io;
 import sample.orders;
 
 public function main() returns error? {
     string ediText = check io:fileReadString("resources/order.edi");
-    orders:OrdersInterchange interchange = check orders:interchangeFromEdiString(ediText);
+    orders:ORDERSInterchange interchange = check orders:interchangeFromEdiString(ediText);
     foreach var txn in interchange.transactions {
         if txn.body is error {
             io:println("Quarantined: ", (<error>txn.body).message());
@@ -55,8 +58,93 @@ public function main() returns error? {
 }
 ```
 
+## Working with standard EDI formats
+
+### EDIFACT — prebuilt packages
+
+For common UN/EDIFACT D03A message types you do not need to generate anything: import a ready-made
+package from the `ballerinax` organization and call its `fromEdiString` / `toEdiString` functions
+directly. Each package groups related message types by business domain.
+
+| Package | Domain |
+|---------|--------|
+| [`ballerinax/edifact.d03a.finance`](https://central.ballerina.io/ballerinax/edifact.d03a.finance) | Credit/debit advices, payment orders, invoices, ledger and tax messages. |
+| [`ballerinax/edifact.d03a.logistics`](https://central.ballerina.io/ballerinax/edifact.d03a.logistics) | Cargo summaries, transport instructions, booking confirmations, dangerous goods. |
+| [`ballerinax/edifact.d03a.manufacturing`](https://central.ballerina.io/ballerinax/edifact.d03a.manufacturing) | Metered consumption, quality data, safety hazards, waste disposal. |
+| [`ballerinax/edifact.d03a.retail`](https://central.ballerina.io/ballerinax/edifact.d03a.retail) | Product and price data, rebate orders, retail settlements, product inquiries. |
+| [`ballerinax/edifact.d03a.services`](https://central.ballerina.io/ballerinax/edifact.d03a.services) | Insurance, healthcare, job applications, berth management, claims. |
+| [`ballerinax/edifact.d03a.shipping`](https://central.ballerina.io/ballerinax/edifact.d03a.shipping) | Container operations, customs declarations, vessel departures, cargo reports. |
+| [`ballerinax/edifact.d03a.supplychain`](https://central.ballerina.io/ballerinax/edifact.d03a.supplychain) | Purchase orders, order responses, delivery forecasts, inventory, despatch advices. |
+
+Each message type is a submodule (e.g. `mINVOIC`, `mORDERS`) exposing `fromEdiString`,
+`toEdiString`, and `getEDINames`:
+
+```ballerina
+import ballerina/io;
+import ballerinax/edifact.d03a.finance.mINVOIC;
+
+public function main() returns error? {
+    string ediText = check io:fileReadString("resources/invoice.edi");
+    mINVOIC:EDI_INVOIC_Invoice invoice = check mINVOIC:fromEdiString(ediText);
+    io:println(invoice);
+}
+```
+
+### X12 — generate from your own spec
+
+X12 message specifications are proprietary (licensed from ASC X12), so no prebuilt X12 packages are
+published. Instead, convert the X12 schema you are licensed to use into a Ballerina EDI schema and
+generate a typed parser from it, exactly like the EDIFACT quickstart above:
+
+```bash
+$ bal edi convertX12Schema -i schema.xsd -o resources/850-schema.json
+$ bal edi codegen -i resources/850-schema.json -o modules/po/po.bal
+```
+
+## Exposed APIs
+
+Most users call the generated functions rather than this module directly, but the module's public
+functions are available for advanced use. The table below is a cursory overview; see the
+[Module Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/ModuleSpecification.md)
+for full signatures, parameters, error types, and envelope semantics.
+
+| Function | Purpose |
+|----------|---------|
+| `getSchema` | Load and validate a JSON EDI schema into an `EdiSchema`. |
+| `fromEdiString` / `toEdiString` | Parse a transaction body to JSON / serialize JSON back to EDI text. |
+| `x12HeadersFromEdiString` / `x12HeadersFromEdiFile` | Schema-free peek at X12 ISA/GS headers — routing and partner identification. |
+| `edifactHeadersFromEdiString` / `edifactHeadersFromEdiFile` | Schema-free peek at EDIFACT UNB/UNH headers. |
+| `headersFromEdiString` / `headersFromEdiFile` | Schema-driven header-only parse. |
+| `interchangeFromEdiString` | Parse the full envelope hierarchy into typed records, with fail-safe per-transaction bodies. |
+| `interchangeToEdiString` | Serialize a full interchange back to EDI text (recomputes envelope counts). |
+
+## Customizing the generated schema
+
+`edi-tools` emits the schema as a JSON file before generating code. Trading partners routinely use
+variations of a standard format, so you can edit this schema to match a partner-specific layout —
+adjust delimiters, segment occurrences (`minOccurances` / `maxOccurances`), field data types, or
+list segments to skip in `ignoreSegments` — then re-run `bal edi codegen` to regenerate the typed
+parser. A minimal schema looks like:
+
+```json
+{
+    "name": "SimpleOrder",
+    "delimiters": {"segment": "~", "field": "*", "component": ":", "repetition": "^"},
+    "segments": [
+        {"code": "HDR", "tag": "header", "minOccurances": 1,
+         "fields": [{"tag": "code"}, {"tag": "orderId"}, {"tag": "organization"}, {"tag": "date"}]},
+        {"code": "ITM", "tag": "items", "maxOccurances": -1,
+         "fields": [{"tag": "code"}, {"tag": "item"}, {"tag": "quantity", "dataType": "int"}]}
+    ]
+}
+```
+
+The [Schema Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md)
+documents the full grammar — delimiters, segments and segment groups, fields / components /
+sub-components, the `envelope` declaration, and the additional configuration options.
+
 ## Documentation
 
-- [Module Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/ModuleSpecification.md) — the full API: the schema-free and schema-driven function families (with an API summary table), envelope and interchange types, error types (`InvalidEnvelopeError`, `SchemaCompatibilityError`, `SerializationError`), and envelope processing semantics (count recomputation on write, UNA handling, single interchange per call).
-- [Schema Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md) — the JSON grammar for EDI schemas: delimiters, segments and segment groups, fields / components / sub-components, the `envelope` declaration, and additional configuration.
-- [edi-tools](https://github.com/ballerina-platform/edi-tools) — converting published X12 / EDIFACT specs into schemas, generating typed records and parser functions (`codegen`), and packaging schema families as libraries (`libgen`).
+- [Module Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/ModuleSpecification.md) — the full API reference and envelope processing semantics.
+- [Schema Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md) — the JSON grammar for EDI schemas.
+- [edi-tools](https://github.com/ballerina-platform/edi-tools) — converting X12 / EDIFACT specs into schemas (`convertX12Schema` / `convertEdifactSchema`), generating typed parsers (`codegen`), and packaging schema families as libraries (`libgen`).

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -76,8 +76,9 @@ directly. Each package groups related message types by business domain.
 | [`ballerinax/edifact.d03a.shipping`](https://central.ballerina.io/ballerinax/edifact.d03a.shipping) | Container operations, customs declarations, vessel departures, cargo reports. |
 | [`ballerinax/edifact.d03a.supplychain`](https://central.ballerina.io/ballerinax/edifact.d03a.supplychain) | Purchase orders, order responses, delivery forecasts, inventory, despatch advices. |
 
-Each message type is a submodule (e.g. `mINVOIC`, `mORDERS`) exposing `fromEdiString`,
-`toEdiString`, and `getEDINames`:
+Each message type is available as a submodule (e.g. `finance.mINVOIC`, `supplychain.mORDERS`)
+exposing `fromEdiString` / `toEdiString`; each package's default module also provides
+`getEDINames()` to list its supported message types:
 
 ```ballerina
 import ballerina/io;
@@ -85,7 +86,7 @@ import ballerinax/edifact.d03a.finance.mINVOIC;
 
 public function main() returns error? {
     string ediText = check io:fileReadString("resources/invoice.edi");
-    mINVOIC:EDI_INVOIC_Invoice invoice = check mINVOIC:fromEdiString(ediText);
+    mINVOIC:EDI_INVOIC_Invoice_message invoice = check mINVOIC:fromEdiString(ediText);
     io:println(invoice);
 }
 ```

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -29,11 +29,12 @@ The fastest path is to generate a typed parser from an EDIFACT or X12 spec using
 Run the following from your Ballerina package to generate the records and parser functions into its default module:
 
 ```bash
-# 1. Convert the EDIFACT D03A ORDERS spec into a Ballerina EDI schema
-$ bal edi convertEdifactSchema -v d03a -t ORDERS -o resources/orders-schema.json
+# 1. Convert the EDIFACT D03A ORDERS spec into a Ballerina EDI schema.
+#    -o is a directory; the schema is written to resources/ORDERS.json (named after the message type).
+$ bal edi convertEdifactSchema -v d03a -t ORDERS -o resources
 
 # 2. Generate Ballerina records and parser functions into the default module
-$ bal edi codegen -i resources/orders-schema.json -o orders.bal
+$ bal edi codegen -i resources/ORDERS.json -o orders.bal
 ```
 
 For X12 use `bal edi convertX12Schema` — see the [edi-tools documentation](https://github.com/ballerina-platform/edi-tools). For larger projects, the generated EDI code can live in its own package within a Ballerina workspace alongside your integration.

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -100,7 +100,7 @@ generate a typed parser from it, exactly like the EDIFACT quickstart above:
 
 ```bash
 $ bal edi convertX12Schema -i schema.xsd -o resources/850-schema.json
-$ bal edi codegen -i resources/850-schema.json -o modules/po/po.bal
+$ bal edi codegen -i resources/850-schema.json -o po.bal
 ```
 
 ## Exposed APIs

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [Fix `convertToType` corrupting numeric values when `decimalSeparator` is a regex metacharacter](https://github.com/ballerina-platform/ballerina-library/issues/8771)
 
+## [1.5.4]
+
+### Fixed
+
+- [Fix ISA02/ISA04 space-padded values incorrectly failing required field validation](https://github.com/ballerina-platform/ballerina-library/issues/8834)
+
 ## [1.5.3] 
 
 ### Changed

--- a/docs/specs/ModuleSpecification.md
+++ b/docs/specs/ModuleSpecification.md
@@ -3,7 +3,7 @@
 _Owners_: @chathurace @RDPerera
 _Reviewers_: @niveathika @chathurace
 _Created_: 2024/01/19
-_Updated_: 2026/04/29
+_Updated_: 2026/06/22
 _Edition_: Swan Lake
 
 ## Introduction
@@ -152,6 +152,23 @@ function toEdiString(json msg, EdiSchema schema) returns string|Error
 
 #### Return Type
 - `string|Error` - EDI text containing the data provided in the JSON variable. Error if the writing fails.
+
+#### Example
+
+```ballerina
+import ballerina/io;
+import ballerina/edi;
+
+public function main() returns error? {
+    edi:EdiSchema schema = check edi:getSchema(check io:fileReadJson("resources/edi-schema.json"));
+    json order = {
+        "header": {"code": "HDR", "orderId": "ORDER_1201", "organization": "ABC_Store", "date": "2008-01-01"},
+        "items": [{"code": "ITM", "item": "A-250", "quantity": 12}]
+    };
+    string ediText = check edi:toEdiString(order, schema);
+    io:println(ediText);
+}
+```
 
 ### 3.4 `x12HeadersFromEdiString` function
 

--- a/docs/specs/SchemaSpecification.md
+++ b/docs/specs/SchemaSpecification.md
@@ -183,7 +183,7 @@ References are resolved by `getSchema` / `denormalizeSchema` before parsing — 
 ]
 ```
 
-### 4. Definition for Fields
+### 4. Fields
 
 Within the `fields` sub-definition, the `length` attribute is used to specify the length constraints for a field. This object includes parameters for fixed length, minimum length, and maximum length, offering comprehensive control over the size of the field.
 
@@ -244,7 +244,7 @@ The `length` value provides the following constraints:
 ]
 ```
 
-### 5. Definition for Components
+### 5. Components
 
 For each component within a field:
 
@@ -271,7 +271,7 @@ For each component within a field:
 ]
 ```
 
-### 6. Definition for Sub-components
+### 6. Sub-components
 
 For each sub-component within a component:
 


### PR DESCRIPTION
Refreshes the user-facing documentation to cover the envelope-aware API (BEP-1441) and fill gaps in the README.

### README / `ballerina/README.md`
- Add the prebuilt **EDIFACT D03A** package list (`ballerinax/edifact.d03a.*`) as the zero-schema path.
- Add the **X12-is-proprietary** note — generate from your own licensed spec.
- Add a cursory **exposed-APIs** table (links to the Module Specification for detail).
- Add a **Customizing the generated schema** section linking the Schema Specification.
- Fix the quickstart's generated interchange type name: `OrdersInterchange` → `ORDERSInterchange`.
- Keep the repo README and package README bodies identical.

### Specs
- `ModuleSpecification.md`: add the missing `toEdiString` example (the rest was already complete from #80).
- `SchemaSpecification.md`: normalize section headings (§4–6) for consistency.

Docs-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This pull request refreshes the user-facing documentation for the Ballerina EDI module to improve clarity, close guidance gaps, and better cover the envelope-aware API (BEP-1441). It is documentation-only, with updates focused on README guidance and specification documentation.

## Key Changes

### README updates (README.md and ballerina/README.md)
- Reworked the documentation structure into a clearer flow with dedicated sections for **Overview**, **Key features**, **Setup**, and **Quickstart**.
- Updated the quickstart example and guidance to use the correct interchange type name (**`ORDERSInterchange`**).
- Added guidance for **Working with standard EDI formats**:
  - Documented **prebuilt EDIFACT D03A** packages (e.g., `ballerinax/edifact.d03a.*`) as the **zero-schema** path.
  - Added a note that **X12 is proprietary** and must be generated from a **user-licensed** specification, with instructions for the convert-and-codegen workflow.
- Added/expanded an **Exposed APIs** table describing the public entry points, including envelope-aware functions and schema-free header/interchange helpers.
- Introduced a **Customizing the generated schema** section, including a minimal schema JSON example and a pointer to the Schema Specification.
- Condensed and refreshed the **Documentation** and **Examples** sections.
- Kept the repository README and package README bodies aligned (identical content).

### Specification document updates (docs/specs)
- **ModuleSpecification.md**
  - Added the missing `toEdiString` usage example (schema loading → JSON message build → serialization).
  - Updated the document’s metadata date.
- **SchemaSpecification.md**
  - Normalized section heading labels for sections 4–6 (Fields/Components/Sub-components).

### Changelog
- Updated **changelog.md** with documentation-related entries (including new/adjusted version notes).

## Impact

These updates make the EDI module’s envelope-aware capabilities easier to understand and use, provide clearer workflows for EDIFACT and X12, and add missing practical examples in the specification materials—without changing any module logic or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->