### PR TITLE
Fix handling loop groups with same segment code

### DIFF
--- a/ballerina/segment_group_reader.bal
+++ b/ballerina/segment_group_reader.bal
@@ -73,6 +73,16 @@ isolated function readSegmentGroup(EdiUnitSchema[] currentUnitSchema, EdiContext
                 check ignoreSchemaGroup(segSchema, sgContext, context);
                 continue;
             }
+            if segSchema.maxOccurances != 1 {
+                EdiSegment|EdiSegment[]|EdiSegmentGroup|EdiSegmentGroup[]? existingGroups = sgContext.segmentGroup[segSchema.tag];
+                if existingGroups is EdiSegmentGroup[] && existingGroups.length() > 0 {
+                    if subsequentSchemaStartsWith(sgContext, fields[0].trim(), sgContext.schemaIndex + 1)
+                            && !qualifierMatchesExistingOccurrence(segSchema, existingGroups[0], fields, ediSchema) {
+                        check ignoreSchemaGroup(segSchema, sgContext, context);
+                        continue;
+                    }
+                }
+            }
             // This logic is very specific to X12 278 dependent loop - 2000D.
             // Made the logic very specific to X12 to avoid any side effects to other messages.
             // FIXME - This is a temporary fix. Need to find a better way to handle this.
@@ -282,4 +292,62 @@ isolated function validateRemainingSchemas(SegmentGroupContext sgContext) return
             i += 1;
         }
     }
+}
+
+isolated function subsequentSchemaStartsWith(SegmentGroupContext sgContext, 
+                                             string segmentCode, int fromIndex) returns boolean {
+    int index = fromIndex;
+    while index < sgContext.unitSchemas.length() {
+        EdiUnitSchema nextSchema = sgContext.unitSchemas[i];
+        if nextSchema is EdiSegGroupSchema {
+            foreach EdiUnitSchema seg in nextSchema.segments {
+                if seg is EdiSegSchema {
+                    if seg.code == segmentCode {
+                        return true;
+                    }
+                    if seg.minOccurances > 0 {
+                        break;
+                    }
+                }
+            }
+        } else if nextSchema is EdiSegSchema {
+            if nextSchema.code == segmentCode {
+                return true;
+            }
+        }
+        index += 1;
+    }
+    return false;
+}
+
+isolated function qualifierMatchesExistingOccurrence(EdiSegGroupSchema segGroupSchema, EdiSegmentGroup firstOccurrence,
+                                                     string[] currentFields, EdiSchema schema) returns boolean {
+    if currentFields.length() < 2 {
+        return true;
+    }
+    EdiSegSchema? openingSegSchema = ();
+    foreach EdiUnitSchema seg in segGroupSchema.segments {
+        if seg is EdiSegSchema {
+            openingSegSchema = seg;
+            break;
+        }
+    }
+    if openingSegSchema is () {
+        return true;
+    }
+
+    int qualifierFieldIndex = schema.includeSegmentCode ? 1 : 0;
+    if openingSegSchema.fields.length() <= qualifierFieldIndex {
+        return true;
+    }
+    string qualifierTag = openingSegSchema.fields[qualifierFieldIndex].tag;
+
+    EdiSegment|EdiSegment[]|EdiSegmentGroup|EdiSegmentGroup[]? storedSeg = firstOccurrence[openingSegSchema.tag];
+    if storedSeg is EdiSegment {
+        EdiComponentGroup|EdiComponentGroup[]|SimpleType|SimpleArray? storedQualifier = storedSeg[qualifierTag];
+        string storedQualifierStr = storedQualifier is string ? storedQualifier : "";
+        string currentQualifier = currentFields[1].trim();
+        return storedQualifierStr == currentQualifier;
+    }
+    return true;
 }

--- a/ballerina/segment_group_reader.bal
+++ b/ballerina/segment_group_reader.bal
@@ -298,7 +298,7 @@ isolated function subsequentSchemaStartsWith(SegmentGroupContext sgContext,
                                              string segmentCode, int fromIndex) returns boolean {
     int index = fromIndex;
     while index < sgContext.unitSchemas.length() {
-        EdiUnitSchema nextSchema = sgContext.unitSchemas[i];
+        EdiUnitSchema nextSchema = sgContext.unitSchemas[index];
         if nextSchema is EdiSegGroupSchema {
             foreach EdiUnitSchema seg in nextSchema.segments {
                 if seg is EdiSegSchema {

--- a/ballerina/tests/resources/qualifier-discrimination/message.edi
+++ b/ballerina/tests/resources/qualifier-discrimination/message.edi
@@ -1,0 +1,6 @@
+HDR*001~
+ENT*A*Alpha1~
+ENT*A*Alpha2~
+ENT*B*Beta1~
+ENT*B*Beta2~
+ENT*C*Gamma~

--- a/ballerina/tests/resources/qualifier-discrimination/message_no_loopA.edi
+++ b/ballerina/tests/resources/qualifier-discrimination/message_no_loopA.edi
@@ -1,0 +1,4 @@
+HDR*001~
+ENT*B*Beta1~
+ENT*B*Beta2~
+ENT*C*Gamma~

--- a/ballerina/tests/resources/qualifier-discrimination/schema.json
+++ b/ballerina/tests/resources/qualifier-discrimination/schema.json
@@ -1,0 +1,76 @@
+{
+  "name": "QualifierTest",
+  "delimiters": {
+    "segment": "~",
+    "field": "*",
+    "component": ":"
+  },
+  "preserveEmptyFields": false,
+  "includeSegmentCode": true,
+  "segments": [
+    {
+      "code": "HDR",
+      "tag": "header",
+      "minOccurances": 1,
+      "maxOccurances": 1,
+      "fields": [
+        {"tag": "code"},
+        {"tag": "id"}
+      ]
+    },
+    {
+      "tag": "LoopTypeA",
+      "minOccurances": 0,
+      "maxOccurances": 3,
+      "segments": [
+        {
+          "code": "ENT",
+          "tag": "entity",
+          "minOccurances": 1,
+          "maxOccurances": 1,
+          "fields": [
+            {"tag": "code"},
+            {"tag": "qualifier", "required": true},
+            {"tag": "name"}
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "LoopTypeB",
+      "minOccurances": 0,
+      "maxOccurances": 3,
+      "segments": [
+        {
+          "code": "ENT",
+          "tag": "entity",
+          "minOccurances": 1,
+          "maxOccurances": 1,
+          "fields": [
+            {"tag": "code"},
+            {"tag": "qualifier", "required": true},
+            {"tag": "name"}
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "LoopTypeC",
+      "minOccurances": 0,
+      "maxOccurances": 1,
+      "segments": [
+        {
+          "code": "ENT",
+          "tag": "entity",
+          "minOccurances": 1,
+          "maxOccurances": 1,
+          "fields": [
+            {"tag": "code"},
+            {"tag": "qualifier", "required": true},
+            {"tag": "name"}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/ballerina/tests/segment_reading_tests.bal
+++ b/ballerina/tests/segment_reading_tests.bal
@@ -107,6 +107,19 @@ function testQualifierBasedLoopDiscrimination() returns error? {
 }
 
 @test:Config
+function testQualifierDiscriminationFirstOccurrenceLimitation() returns error? {
+    json schemaJson = check io:fileReadJson("tests/resources/qualifier-discrimination/schema.json");
+    EdiSchema schema = check getSchema(schemaJson);
+    string ediText = check io:fileReadString("tests/resources/qualifier-discrimination/message_no_loopA.edi");
+    json result = check fromEdiString(ediText, schema);
+
+    json loopA = check result.LoopTypeA;
+    test:assertTrue(loopA is json[], "LoopTypeA should be an array (receives ENT*B due to first-occurrence limitation)");
+    json[] loopAArr = <json[]>loopA;
+    test:assertEquals(loopAArr.length(), 2, "LoopTypeA incorrectly captures both ENT*B segments due to first-occurrence limitation");
+}
+
+@test:Config
 function testDenormalization() returns error? {
     json schemaJson = check io:fileReadJson("tests/resources/denormalization/normalized_schema.json");
     EdiSchema schema = check getSchema(schemaJson);

--- a/ballerina/tests/segment_reading_tests.bal
+++ b/ballerina/tests/segment_reading_tests.bal
@@ -79,6 +79,34 @@ function testDynamicLengthEDIsWithWrongSchema1(string testName) returns error? {
 }
 
 @test:Config
+function testQualifierBasedLoopDiscrimination() returns error? {
+    json schemaJson = check io:fileReadJson("tests/resources/qualifier-discrimination/schema.json");
+    EdiSchema schema = check getSchema(schemaJson);
+    string ediText = check io:fileReadString("tests/resources/qualifier-discrimination/message.edi");
+    json result = check fromEdiString(ediText, schema);
+
+    // LoopTypeA should contain two ENT*A entries (not ENT*B or ENT*C)
+    json loopA = check result.LoopTypeA;
+    test:assertTrue(loopA is json[], "LoopTypeA should be an array");
+    json[] loopAArr = <json[]>loopA;
+    test:assertEquals(loopAArr.length(), 2, "LoopTypeA should have 2 occurrences (ENT*A*Alpha1 and ENT*A*Alpha2)");
+    test:assertEquals(check loopAArr[0].entity.qualifier, "A", "LoopTypeA[0] qualifier should be 'A'");
+    test:assertEquals(check loopAArr[1].entity.qualifier, "A", "LoopTypeA[1] qualifier should be 'A'");
+
+    // LoopTypeB should contain two ENT*B entries
+    json loopB = check result.LoopTypeB;
+    test:assertTrue(loopB is json[], "LoopTypeB should be an array");
+    json[] loopBArr = <json[]>loopB;
+    test:assertEquals(loopBArr.length(), 2, "LoopTypeB should have 2 occurrences (ENT*B*Beta1 and ENT*B*Beta2)");
+    test:assertEquals(check loopBArr[0].entity.qualifier, "B", "LoopTypeB[0] qualifier should be 'B'");
+
+    // LoopTypeC should contain one ENT*C entry
+    json loopC = check result.LoopTypeC;
+    test:assertTrue(!(loopC is json[]), "LoopTypeC should not be an array (maxOccurances=1)");
+    test:assertEquals(check loopC.entity.qualifier, "C", "LoopTypeC qualifier should be 'C'");
+}
+
+@test:Config
 function testDenormalization() returns error? {
     json schemaJson = check io:fileReadJson("tests/resources/denormalization/normalized_schema.json");
     EdiSchema schema = check getSchema(schemaJson);

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [Fix `convertToType` corrupting numeric values when `decimalSeparator` is a regex metacharacter](https://github.com/ballerina-platform/ballerina-library/issues/8771)
 - [Fix ISA02/ISA04 space-padded values incorrectly failing required field validation](https://github.com/ballerina-platform/ballerina-library/issues/8834)
+- [Fix EDI parser incorrectly matches repeatable segment groups](https://github.com/ballerina-platform/ballerina-library/issues/8862)
 
 ## [1.5.4]
 


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8862

Currently when EDI parser reads an EDI segment, it only checks the segment code to verify whether it belongs to the same group or a different one.

But ideally it should check both segment code and the qualifier.

### Solution
Added two separate methods as `subsequentSchemaStartsWith` and `qualifierMatchesExistingOccurrence`

1. The `subsequentSchemaStartsWith` method

Before applying any qualifier logic, we need to check whether there is actually an ambiguity there. Ambiguity only exists when another sibling schema at the same level also opens with the same segment code. This method is to check that.

2. The `qualifierMatchesExistingOccurrence ` method

Once ambiguity is confirmed we need to compare the `qualifier of the incoming segment` against the qualifier stored in the first occurrence of the current group.
If they match, we can conclude that the incoming segment belongs to the same group as the previous one. If not it would belong to a different one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated EDI segment-group parsing to better distinguish repeatable sibling groups that begin with the same segment code. The parser now considers both the segment code and qualifier when resolving group matches, which helps assign segments to the correct loop and avoids incorrect group consumption in valid transactions.

Added targeted tests and fixture data to cover qualifier-based loop discrimination, including a case that verifies the expected first-occurrence behavior. Also updated the changelog to note the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->