### PR TITLE
Fix the non-compiling envelope sample in the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@ public function main() returns error? {
     string ediText = check io:fileReadString("resources/order.edi");
     ORDERSInterchange interchange = check interchangeFromEdiString(ediText);
     foreach var txn in interchange.transactions {
-        if txn.body is error {
-            io:println("Quarantined: ", txn.body.message());
+        ORDERS|error body = txn.body;
+        if body is error {
+            io:println("Quarantined: ", body.message());
             continue;
         }
-        io:println(txn.body);
+        io:println(body);
     }
 }
 ```

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -50,11 +50,12 @@ public function main() returns error? {
     string ediText = check io:fileReadString("resources/order.edi");
     ORDERSInterchange interchange = check interchangeFromEdiString(ediText);
     foreach var txn in interchange.transactions {
-        if txn.body is error {
-            io:println("Quarantined: ", txn.body.message());
+        ORDERS|error body = txn.body;
+        if body is error {
+            io:println("Quarantined: ", body.message());
             continue;
         }
-        io:println(txn.body);
+        io:println(body);
     }
 }
 ```


### PR DESCRIPTION
### Purpose

The envelope sample in both READMEs does not compile:

```ballerina
if txn.body is error {
    io:println("Quarantined: ", txn.body.message());
```

Ballerina narrows variable references, not field accesses, so `txn.body` stays `ORDERS|error` inside that branch:

```
ERROR undefined function 'message' in type '(ORDERS|error)'
```

This was introduced in 5da41b5, which dropped `(<error>txn.body)` as a redundant cast in response to review. The cast was load-bearing. Rather than restore it, the sample now binds the body to a local, which matches the samples in the EDI tool page, the BBEs, and the integration guides.

Fixes ballerina-platform/ballerina-spec#1441.

### Checklist
- [x] Verified the corrected pattern compiles and runs both branches
- [x] Swept the repo for other occurrences (none remain)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the envelope parsing examples in both READMEs. The examples now bind `txn.body` to a local `ORDERS|error` variable before error checking. This allows correct type narrowing and ensures the samples compile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->