### PR TITLE
Fix doc comment grammar and name types instead of using var

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ import ballerina/io;
 public function main() returns error? {
     string ediText = check io:fileReadString("resources/order.edi");
     ORDERSInterchange interchange = check interchangeFromEdiString(ediText);
-    foreach var txn in interchange.transactions {
+    foreach ORDERSTransaction txn in interchange.transactions {
         ORDERS|error body = txn.body;
         if body is error {
             io:println("Quarantined: ", body.message());

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -52,7 +52,7 @@ import ballerina/io;
 public function main() returns error? {
     string ediText = check io:fileReadString("resources/order.edi");
     ORDERSInterchange interchange = check interchangeFromEdiString(ediText);
-    foreach var txn in interchange.transactions {
+    foreach ORDERSTransaction txn in interchange.transactions {
         ORDERS|error body = txn.body;
         if body is error {
             io:println("Quarantined: ", body.message());

--- a/ballerina/edi_translator.bal
+++ b/ballerina/edi_translator.bal
@@ -219,7 +219,7 @@ isolated function mergeTransactionBodies(json base, json addition) returns json|
     return result;
 }
 
-# Writes the given JSON varibale into a EDI text according to the provided schema.
+# Writes the given JSON variable into an EDI text according to the provided schema.
 #
 # + msg - JSON value to be written into EDI
 # + schema - Schema of the EDI text

--- a/ballerina/envelope_parser.bal
+++ b/ballerina/envelope_parser.bal
@@ -771,7 +771,7 @@ isolated function readFileChars(string filePath, int maxChars) returns string|Er
         string text = check charCh.read(maxChars);
         check charCh.close();
         return text;
-    } on fail var e {
+    } on fail error e {
         return error Error(string `Failed to read EDI file '${filePath}': ${e.message()}`, e);
     }
 }

--- a/ballerina/schema_types.bal
+++ b/ballerina/schema_types.bal
@@ -22,7 +22,7 @@
 #
 # + delimiters - Delimiters used to separate EDI segments, fields, components, etc.  
 #
-# + ignoreSegments - List of segment schemas to be ignored when matching a EDI text. 
+# + ignoreSegments - List of segment schemas to be ignored when matching an EDI text. 
 # For example, if it is necessary to process X12 transaction sets only, without ISA as GS segments,
 # and if the schema contains ISA and GS segments as well, ISA and GS can be provided as ignoreSegments.
 #

--- a/ballerina/segment_group_reader.bal
+++ b/ballerina/segment_group_reader.bal
@@ -163,7 +163,7 @@ isolated function ignoreSchemaGroup(EdiSegGroupSchema segGroupSchema, SegmentGro
     // at least one such segment group, we can ignore the current mapping and compare the current segment with
     // the next mapping.
     if segGroupSchema.maxOccurances != 1 {
-        var segments = sgContext.segmentGroup[segGroupSchema.tag];
+        EdiSegment|EdiSegment[]|EdiSegmentGroup|EdiSegmentGroup[]? segments = sgContext.segmentGroup[segGroupSchema.tag];
         if segments is EdiSegment[]|EdiSegmentGroup[] {
             if segments.length() > 0 {
                 // This repeatable segment has already occured at least once. So move to the next mapping.
@@ -212,7 +212,7 @@ isolated function ignoreSchema(EdiUnitSchema segSchema, SegmentGroupContext sgCo
     // at least one such segment, we can ignore the current mapping and compare the current segment with 
     // the next mapping.
     if segSchema.maxOccurances != 1 {
-        var segments = sgContext.segmentGroup[segSchema.tag];
+        EdiSegment|EdiSegment[]|EdiSegmentGroup|EdiSegmentGroup[]? segments = sgContext.segmentGroup[segSchema.tag];
         if segments is EdiSegment[]|EdiSegmentGroup[] {
             if segments.length() > 0 {
                 // This repeatable segment has already occured at least once. So move to the next mapping.
@@ -241,7 +241,7 @@ isolated function placeEDISegment(EdiSegment segment, EdiSegSchema segSchema, Se
         // Current mapping points to a repeatable segment. So we are using an EDISegment[] array to hold segments.
         // Also we can't increment the mapping index here as next segment can also match with the current mapping
         // as the segment is repeatable.
-        var segments = sgContext.segmentGroup[segSchema.tag];
+        EdiSegment|EdiSegment[]|EdiSegmentGroup|EdiSegmentGroup[]? segments = sgContext.segmentGroup[segSchema.tag];
         if segments is EdiSegment[] {
             if (segSchema.maxOccurances != -1 && segments.length() >= segSchema.maxOccurances) {
                 return error Error(string `Maximum allowed unit count of the repeatable unit is exceeded.
@@ -265,7 +265,7 @@ isolated function placeEDISegmentGroup(EdiSegmentGroup segmentGroup, EdiSegGroup
     } else {
         // This is a repeatable mapping. So we compare the next segment also with the current mapping.
         // i.e. we don't increment the mapping index.
-        var segmentGroups = sgContext.segmentGroup[segGroupSchema.tag];
+        EdiSegment|EdiSegment[]|EdiSegmentGroup|EdiSegmentGroup[]? segmentGroups = sgContext.segmentGroup[segGroupSchema.tag];
         if segmentGroups is EdiSegmentGroup[] {
             if segGroupSchema.maxOccurances != -1 && segmentGroups.length() >= segGroupSchema.maxOccurances {
                 return error Error(string `Number of (multi-occurance) segment groups in the input exceeds the allowed maximum limit in the schema.

--- a/ballerina/segment_group_reader.bal
+++ b/ballerina/segment_group_reader.bal
@@ -238,7 +238,7 @@ isolated function placeEDISegment(EdiSegment segment, EdiSegSchema segSchema, Se
         sgContext.schemaIndex += 1;
         sgContext.segmentGroup[segSchema.tag] = segment;
     } else {
-        // Current mapping points to a repeatable segment. So we are using a EDISegment[] array to hold segments.
+        // Current mapping points to a repeatable segment. So we are using an EDISegment[] array to hold segments.
         // Also we can't increment the mapping index here as next segment can also match with the current mapping
         // as the segment is repeatable.
         var segments = sgContext.segmentGroup[segSchema.tag];

--- a/ballerina/segment_writer.bal
+++ b/ballerina/segment_writer.bal
@@ -73,7 +73,7 @@ isolated function writeSegment(map<json> seg, EdiSegSchema segMap, EdiContext co
             }
             segLine += fd + repeatingText;
         } else {
-            var fdata = seg.get(fieldSchema.tag);
+            json fdata = seg.get(fieldSchema.tag);
             if fieldSchema.length is Range {
                 Range fieldLength = <Range>fieldSchema.length;
                 if fieldLength.min > fdata.toString().length() {

--- a/examples/adapt-edi-schema/edi_parser/edi.bal
+++ b/examples/adapt-edi-schema/edi_parser/edi.bal
@@ -84,7 +84,7 @@ public isolated function interchangeFromEdiString(string ediText) returns ORDERS
     edi:EdiSchema ediSchema = check edi:getSchema(schemaJson);
     edi:EdiInterchange raw = check edi:interchangeFromEdiString(ediText, ediSchema);
     ORDERSTransaction[] txns = [];
-        foreach var t in raw.transactions ?: [] {
+        foreach edi:EdiTransaction t in raw.transactions ?: [] {
             ORDERS|error body = convertORDERSBody(t.body);
             ORDERSTransactionHeader th = check t.transactionHeader.cloneWithType();
             ORDERSTransactionTrailer tt = check t.transactionTrailer.cloneWithType();
@@ -106,7 +106,7 @@ public isolated function interchangeToEdiString(ORDERSInterchange msg) returns s
     edi:EdiInterchange raw;
     {
         edi:EdiTransaction[] rawTxns = [];
-        foreach var t in msg.transactions {
+        foreach ORDERSTransaction t in msg.transactions {
             json|error body = unwrapORDERSBody(t.body);
             rawTxns.push({
                 transactionHeader: t.transactionHeader.toJson(),

--- a/examples/edi-order-generator/edi_parser/edi.bal
+++ b/examples/edi-order-generator/edi_parser/edi.bal
@@ -84,7 +84,7 @@ public isolated function interchangeFromEdiString(string ediText) returns ORDERS
     edi:EdiSchema ediSchema = check edi:getSchema(schemaJson);
     edi:EdiInterchange raw = check edi:interchangeFromEdiString(ediText, ediSchema);
     ORDERSTransaction[] txns = [];
-        foreach var t in raw.transactions ?: [] {
+        foreach edi:EdiTransaction t in raw.transactions ?: [] {
             ORDERS|error body = convertORDERSBody(t.body);
             ORDERSTransactionHeader th = check t.transactionHeader.cloneWithType();
             ORDERSTransactionTrailer tt = check t.transactionTrailer.cloneWithType();
@@ -106,7 +106,7 @@ public isolated function interchangeToEdiString(ORDERSInterchange msg) returns s
     edi:EdiInterchange raw;
     {
         edi:EdiTransaction[] rawTxns = [];
-        foreach var t in msg.transactions {
+        foreach ORDERSTransaction t in msg.transactions {
             json|error body = unwrapORDERSBody(t.body);
             rawTxns.push({
                 transactionHeader: t.transactionHeader.toJson(),

--- a/examples/edi-parser-to-kafka/edi_parser/edi.bal
+++ b/examples/edi-parser-to-kafka/edi_parser/edi.bal
@@ -93,7 +93,7 @@ public isolated function interchangeFromEdiString(string ediText) returns ORDERS
         return {interchangeHeader: ih, transactions: txns, interchangeTrailer: it};
 }
 
-# Serialize a ORDERSInterchange into EDI text; the inverse of interchangeFromEdiString.
+# Serialize the ORDERSInterchange into EDI text; the inverse of interchangeFromEdiString.
 # A transaction whose body is an error is refused — filter or replace it before calling.
 #
 # + msg - The interchange to serialize
@@ -1601,7 +1601,7 @@ public type ORDERSTransactionTrailer record {|
 
 
 
-# A single transaction within a ORDERS interchange.
+# A single transaction within the ORDERS interchange.
 #
 # + transactionHeader - Transaction header segment
 # + body - Parsed ORDERS body, or the parse error when the body is malformed
@@ -1623,7 +1623,7 @@ public type ORDERSInterchange record {|
     ORDERSInterchangeTrailer interchangeTrailer;
 |};
 
-# Envelope headers of a ORDERS interchange.
+# Envelope headers of the ORDERS interchange.
 #
 # + interchange - Interchange header
 # + 'transaction - Transaction header


### PR DESCRIPTION
### Purpose

Grammar fixes in doc comments, found while addressing a review comment on the now-merged #98.

- `edi_translator.bal` — "Writes the given JSON **varibale** into **a** EDI text" → "variable" / "an EDI text". This is a public doc comment.
- `schema_types.bal` — "when matching **a** EDI text" → "an EDI text". Also public.
- `segment_group_reader.bal` — "using **a** EDISegment[] array" → "an".
- `examples/edi-parser-to-kafka/edi_parser/edi.bal` — "**a** ORDERSInterchange", "within **a** ORDERS interchange", "Envelope headers of **a** ORDERS interchange" → `the`, matching what the codegen template now emits after ballerina-platform/edi-tools#79.

The template was wrong for every schema name starting with a vowel sound — ORDERS, INVOIC, APERAK, 850 — across five lines, so it now uses `the`, which is correct whatever the name is.

### Not changed

`minOccurances` / `maxOccurances` are misspelled ("occurrences"), but they are public API: field names in the EDI schema JSON format and in every generated module. Renaming them would break existing schemas, so they are left as they are.

Fixes ballerina-platform/ballerina-spec#1441.

### Checklist
- [x] `bal test` — 69 passing, 0 failing
- [x] Swept the module and examples for other article errors; `an FL` / `an SFTP` are correct as-is

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Corrected spelling and article usage in public and generated EDI documentation.
- Replaced inferred local types with explicit types in examples and parser files.
- Preserved the public API fields `minOccurances` and `maxOccurances`.
- No runtime behavior changed.
- Tests: 69 passed, 0 failed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->