### PR TITLE
Bump the module version to 1.7.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=1.6.1-SNAPSHOT
+version=1.7.0-SNAPSHOT
 
 checkstylePluginVersion=10.12.0
 spotbugsPluginVersion=6.0.18


### PR DESCRIPTION
Bumps the module version to `1.7.0`.

#102 added the `values` and `discriminator` schema attributes — a backward-compatible feature addition — so the next release is a minor one. That PR was merged without the version change, hence this follow-up.

Only `gradle.properties` is changed. `ballerina/Ballerina.toml` is rendered from `build-config/resources/Ballerina.toml` by the `updateTomlFiles` task, which substitutes `@toml.version@` with this version, and `Dependencies.toml` is regenerated by the build — both are committed by the automated "Update the native jar versions" step rather than edited by hand.
